### PR TITLE
Added external RG support for KV and STG

### DIFF
--- a/arm-templates/Function/azuredeploy.json
+++ b/arm-templates/Function/azuredeploy.json
@@ -2,13 +2,33 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "storageAccountRG": {
+            "defaultValue": "[resourceGroup().name]",
+            "type": "String",
+            "metadata": {
+                "description": "The name of the resource group where storage account has deployed."
+            }
+        },
         "storageAccountName": {
             "defaultValue": "akvrotationstorage",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "The name of the existing storage account with access keys to rotate."
+            }
+        },
+        "keyVaultRG": {
+            "defaultValue": "[resourceGroup().name]",
+            "type": "String",
+            "metadata": {
+                "description": "The name of the resource group where key vault has deployed."
+            }
         },
         "keyVaultName": {
             "defaultValue": "akvrotation-kv",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "The name of the existing key vault where secrets are stored."
+            }
         },
         "functionAppName": {
             "defaultValue": "akvrotation-fnapp",
@@ -16,8 +36,8 @@
             "metadata": {
                 "description": "The name of the function app that you wish to create."
             }
-		},
-		"secretName": {
+        },
+        "secretName": {
             "defaultValue": "storageKey",
             "type": "String",
             "metadata": {
@@ -33,9 +53,8 @@
         }
     },
     "variables": {
-		"functionStorageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
-		"eventSubscriptionName": "[concat(parameters('keyVaultName'),'-',parameters('secretName'),'-',parameters('functionAppName'))]"
-		
+        "functionStorageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
+        "eventSubscriptionName": "[concat(parameters('keyVaultName'),'-',parameters('secretName'),'-',parameters('functionAppName'))]"
     },
     "resources": [
         {
@@ -142,64 +161,92 @@
             }
         },
         {
-            "type": "Microsoft.KeyVault/vaults/accessPolicies",
-            "apiVersion": "2018-02-14",
-            "name": "[concat(parameters('keyVaultName'), '/add')]",
+            "name": "kv-grant-access",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "resourceGroup": "[parameters('keyVaultRG')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
+                "[concat(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'/sourcecontrols/web')]"
             ],
             "properties": {
-                "accessPolicies": [
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'2019-08-01', 'Full').identity.principalId]",
-                        "permissions": {
-                            "keys": [],
-                            "secrets": [
-                                "Get",
-                                "List",
-                                "Set"
-                            ],
-                            "certificates": []
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.KeyVault/vaults/accessPolicies",
+                            "name": "[concat(parameters('keyVaultName'), '/add')]",
+                            "apiVersion": "2019-09-01",
+                            "properties": {
+                                "accessPolicies": [
+                                    {
+                                        "tenantId": "[subscription().tenantId]",
+                                        "objectId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'2019-08-01', 'Full').identity.principalId]",
+                                        "permissions": {
+                                            "secrets": [
+                                                "Get",
+                                                "List",
+                                                "Set"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Microsoft.KeyVault/vaults/providers/eventSubscriptions",
+                            "apiVersion": "2020-01-01-preview",
+                            "name": "[concat(parameters('keyVaultName'),'/Microsoft.EventGrid/',variables('eventSubscriptionName'))]",
+                            "location": "[resourceGroup().location]",
+                            "properties": {
+                                "destination": {
+                                    "endpointType": "AzureFunction",
+                                    "properties": {
+                                        "maxEventsPerBatch": 1,
+                                        "preferredBatchSizeInKilobytes": 64,
+                                        "resourceId": "[concat(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'/functions/AKVStorageRotation')]"
+                                    }
+                                },
+                                "filter": {
+                                    "subjectBeginsWith": "[parameters('secretName')]",
+                                    "subjectEndsWith": "[parameters('secretName')]",
+                                    "includedEventTypes": [ "Microsoft.KeyVault.SecretNearExpiry" ]
+
+                                }
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
-		},
-		{
-            "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
-            "apiVersion": "2018-09-01-preview",
-            "name": "[concat(parameters('storageAccountName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('storageAccountName'))))]",
+        },
+        {
+            "name": "stg-grant-access",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "resourceGroup": "[parameters('storageAccountRG')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
             ],
             "properties": {
-                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '81a9662b-bebf-436f-a333-f67b29880f12')]",
-                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'2019-08-01', 'Full').identity.principalId]"
-            }
-		},
-		{
-            "type": "Microsoft.KeyVault/vaults/providers/eventSubscriptions",
-            "apiVersion": "2020-01-01-preview",
-            "name": "[concat(parameters('keyVaultName'),'/Microsoft.EventGrid/',variables('eventSubscriptionName'))]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Web/sites/', parameters('functionAppName'),'/sourcecontrols/web')]"
-            ],
-            "properties": {
-                "destination": {
-                    "endpointType": "AzureFunction",
-                    "properties": {
-                        "maxEventsPerBatch": 1,
-                        "preferredBatchSizeInKilobytes": 64,
-                        "resourceId": "[concat(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'/functions/AKVStorageRotation')]"
-                    }
-                },
-                "filter": {
-					"subjectBeginsWith": "[parameters('secretName')]",
-      				"subjectEndsWith": "[parameters('secretName')]",
-					"includedEventTypes": ["Microsoft.KeyVault.SecretNearExpiry"]
-					
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
+                            "apiVersion": "2018-09-01-preview",
+                            "name": "[concat(parameters('storageAccountName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('storageAccountName'))))]",
+                            "properties": {
+                                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '81a9662b-bebf-436f-a333-f67b29880f12')]",
+                                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')),'2019-08-01', 'Full').identity.principalId]"
+                            }
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
In some scenarios, Storage Account & Key Vault may exist in the different RGs.
Default functionality kept with [resourceGroup().name] defaults.